### PR TITLE
Install android-21 in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ android:
 
     # The SDK version used to compile your project
     - android-15
-    - android-22
+    - android-21
     - android-25
 
     # Additional components


### PR DESCRIPTION
### What has been done
- Use correct android image (21 instead of 22). No idea how it worked before actually (was preinstalled in Travis?).