### PR TITLE
Fix Circle CI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/code
     docker:
-      - image: circleci/android:api-25-alpha
+      - image: circleci/android:api-28-alpha
     environment:
       JVM_OPTS: -Xmx3200m
       ADB_INSTALL_TIMEOUT: 10

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
           command: echo "no" | avdmanager create avd -n test -k "system-images;android-21;default;armeabi-v7a"
       - run:
           name: Launch emulator
-          command: export LD_LIBRARY_PATH=${ANDROID_HOME}/emulator/lib64:${ANDROID_HOME}/emulator/lib64/qt/lib && emulator64-arm -avd test -noaudio -no-boot-anim -no-window -accel on
+          command: export LD_LIBRARY_PATH=${ANDROID_HOME}/emulator/lib64:${ANDROID_HOME}/emulator/lib64/qt/lib && emulator -avd test -noaudio -no-boot-anim -no-window -accel on
           background: true
       - run:
           name: Wait for emulator


### PR DESCRIPTION
Fixes #28 

### What has been done
- Updated Docker image used from [API 25 alpha](https://github.com/CircleCI-Public/circleci-dockerfiles/tree/37da70dc5f3e4108dbaa4eb608a30b86fb1147e6/android/images/api-25-alpha) to [API 28 alpha](https://github.com/CircleCI-Public/circleci-dockerfiles/tree/37da70dc5f3e4108dbaa4eb608a30b86fb1147e6/android/images/api-28-alpha)
- Used `emulator` instead of `emulator64-arm`