### PR TITLE
Use 1.27.1 version of Fabric plugin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,9 @@ jobs:
       - restore_cache:
           key: jars-{{ checksum "build.gradle" }}-{{ checksum  "app/build.gradle" }}
       - run:
+          name: Accept Android Licenses
+          command: yes | sdkmanager --licenses && yes | sdkmanager --update  || exit 0
+      - run:
           name: Download Dependencies
           command: ./gradlew clean androidDependencies
       - save_cache:

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.2'
-        classpath 'io.fabric.tools:gradle:1.+'
+        classpath 'io.fabric.tools:gradle:1.27.1'
         classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.7.1'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/shippable.yml
+++ b/shippable.yml
@@ -16,6 +16,7 @@ build:
       - mkdir "$ANDROID_HOME/licenses" || true
       - echo -e "\n8933bad161af4178b1185d1a37fbf41ea5269c55" > "$ANDROID_HOME/licenses/android-sdk-license"
       - echo -e "\nd56f5187479451eabf01fb78af6dfcb131a6481e" > "$ANDROID_HOME/licenses/android-sdk-license"
+      - echo -e "\n24333f8a63b6825ea9c5514f83c2829b004d1fee" > "$ANDROID_HOME/licenses/android-sdk-license"
       - echo -e "\n84831b9409646a918e30573bab4c9c91346d8abd" > "$ANDROID_HOME/licenses/android-sdk-preview-license"
       # install missing Android dependencies
       - echo y | android update sdk --no-ui --all --filter "android-15,android-21,android-22,android-25,build-tools-24.0.3"


### PR DESCRIPTION
### What has been done
- Use 1.27.1 version of Fabric plugin. Not willing to update to a higher version at this point as it causes other compilation issues and requires more changes.