### PR TITLE
Switch to shell script from Gradle runner at bitrise

### DIFF
--- a/.bitrise.yml
+++ b/.bitrise.yml
@@ -13,13 +13,27 @@ workflows:
         run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
     - git-clone@4.0.12: {}
     - install-missing-android-tools@2.2.0: {}
-    - gradle-runner@1.8.3:
+    - script@1.1.5:
+        inputs:Switched to shell script from Gradle runner at bitrise (#36)
+        - content: |-
+            #!/usr/bin/env bash
+            # fail if any commands fails
+            set -e
+            # debug log
+            set -x
+
+            unset ANDROID_NDK_HOME
+
+            ./gradlew assembleDebug testDebug jacocoTestReport checkstyle pmd jdepend lintDebug buildDashboard assembleDebugAndroidTest crashlyticsUploadDistributionDebug -PversionCode=$BITRISE_BUILD_NUMBER -PfabricApiKey=$FABRIC_API_KEY -PfabricApiSecret=$FABRIC_API_SECRET
         title: Gradle Build/Test/Analyse/Distribute
-        inputs:
-        - gradle_task: assembleDebug testDebug jacocoTestReport checkstyle pmd jdepend
-            lintDebug buildDashboard crashlyticsUploadDistributionDebug -PversionCode=$BITRISE_BUILD_NUMBER
-            -PfabricApiKey=$FABRIC_API_KEY -PfabricApiSecret=$FABRIC_API_SECRET
-        - mapping_file_exclude_filter: ''
+# disabled because of https://github.com/vgaidarji/ci-matters/issues/35
+#    - gradle-runner@1.8.3:
+#        title: Gradle Build/Test/Analyse/Distribute
+#        inputs:
+#        - gradle_task: assembleDebug testDebug jacocoTestReport checkstyle pmd jdepend
+#            lintDebug buildDashboard crashlyticsUploadDistributionDebug -PversionCode=$BITRISE_BUILD_NUMBER
+#            -PfabricApiKey=$FABRIC_API_KEY -PfabricApiSecret=$FABRIC_API_SECRET
+#        - mapping_file_exclude_filter: ''
     - gradle-coveralls@1.0.1:
         inputs:
         - coveralls_task: coveralls -PversionCode=$BITRISE_BUILD_NUMBER -PfabricApiKey=$FABRIC_API_KEY


### PR DESCRIPTION
### What has been done
Temporarily disabled Gradle runner step because of https://github.com/vgaidarji/ci-matters/issues/35.

Fixes #27 

### Alternative solution
Just use custom version of gradle runner step as follows (from [this commit](https://github.com/bitrise-steplib/steps-gradle-runner/commit/2f330b7469936fd092fe65d26b4643b8d5a14a5f))
```
    - git::https://github.com/bitrise-io/steps-gradle-runner.git@unset_ndk_home:
        title: Gradle Build/Test/Analyse/Distribute
        inputs:
        - gradle_task: assembleDebug testDebug jacocoTestReport checkstyle pmd jdepend
            lintDebug buildDashboard assembleDebugAndroidTest crashlyticsUploadDistributionDebug
            -PversionCode=$BITRISE_BUILD_NUMBER -PfabricApiKey=$FABRIC_API_KEY -PfabricApiSecret=$FABRIC_API_SECRET
        - mapping_file_exclude_filter: ''
```